### PR TITLE
TFRecords: process and parse with multiple tag databases

### DIFF
--- a/preprocessing.py
+++ b/preprocessing.py
@@ -276,33 +276,19 @@ def save_example_to_tfrecord(df, output_path, audio_format, root_dir, tag_path, 
             # resample audio array into 'sample_rate' and convert into 'audio_format'
             processed_array = process_array(unsampled_audio['array'], audio_format, sr_in=unsampled_audio['sr'], sr_out=sample_rate, n_mels=n_mels)
             
-            # create the tf.Example
+            # load the tf.Example
             example = get_example(processed_array, tid, encoded_tags)
             
-            # save to disk
+            # save the tf.Example into a .tfrecord file
             writer.write(example.SerializeToString())
     
-
-        # try to re-handle exceptions (sometimes it works!!); otherwise, skip
+        # print exceptions
         if set(df.columns) == {'track_id', 'npz_path'}:
             return
         else:
-            for exception in exceptions:
-                print("Handling exception {}...".format(exception['path']), end=" ", flush=True)
-                try:
-                    array, sr = librosa.core.load(exception['path'], sr=None)
-                except:
-                    print("FAIL. Skipping...")
-                    continue
-                print("SUCCESS!")
-                unsampled_audio = {'array': array, 'sr': sr}
-
-                # resample audio array into 'sample_rate' and convert into 'audio_format'
-                processed_array = process_array(unsampled_audio['array'], audio_format, sr_in=unsampled_audio['sr'], sr_out=sample_rate, n_mels=n_mels)
-                
-                # create and save a tf.Example
-                example = get_example(processed_array, exception['tid'], exception['encoded_tags'])
-                writer.write(example.SerializeToString())
+            print('Could not process the following tracks:')
+            for i, exception in enumerate(exceptions):
+                print(" {:3d}. {} {}".format(i, exception["tid"] + exception["path"]))
             return
 
 if __name__ == '__main__':

--- a/preprocessing.py
+++ b/preprocessing.py
@@ -412,7 +412,7 @@ if __name__ == '__main__':
             df_slice = df.loc[(args.num_files-1)*len(df)//args.num_files:]
             # create and save to the .tfrecord file
             save_example_to_tfrecord(df_slice, filename, audio_format=args.format, 
-                                     root_dir=args.root_dir, tag_path=args.tag_path, 
-                                     multitag=args.tag_path_multi,
-                                     sample_rate=args.sr, n_mels=args.mels,
-                                     verbose=args.verbose)
+                                        root_dir=args.root_dir, tag_path=args.tag_path, 
+                                        multitag=args.tag_path_multi,
+                                        sample_rate=args.sr, n_mels=args.mels,
+                                        verbose=args.verbose)

--- a/preprocessing.py
+++ b/preprocessing.py
@@ -212,7 +212,7 @@ def save_example_to_tfrecord(df, output_path, audio_format, root_dir, tag_path, 
         The number of mels in the mel-spectrogram.
     
     multitag: list
-        If not None, encode multiple tags at the same time (feature names will be 'tag-0', 'tag-1' etc.)
+        If not None, encode multiple tags at the same time (provide as list of filenames; feature names will be 'tag-0', 'tag-1' etc.)
 
     verbose: bool
         If True, print progress.
@@ -295,10 +295,10 @@ if __name__ == '__main__':
     parser = argparse.ArgumentParser()
     parser.add_argument("format", choices=["waveform", "log-mel-spectrogram"], help="output format of audio")
     parser.add_argument("output", help="directory to save .tfrecord files in")
-    parser.add_argument("--root-dir", help="set path to directory containing the .npz files, defaults to path on Boden", default='/srv/data/msd/7digital/')
-    parser.add_argument("--csv-path", help="set path to .csv file, defaults to path on Boden", default='/srv/data/urop/ultimate.csv')
-    parser.add_argument("--tag-path", help="set path to 'clean' tags database, defaults to path on Boden", default='/srv/data/urop/clean_lastfm.db')
-    parser.add_argument("--tag-path-multi", help="encode multiple tags databases at the same time (supply as list of .db files, use --tag-path as root directory)", nargs='+')
+    parser.add_argument("--root-dir", help="set path to directory containing the .npz files (defaults to path on Boden)", default='/srv/data/msd/7digital/')
+    parser.add_argument("--csv-path", help="set path to .csv file (defaults to path on Boden)", default='/srv/data/urop/ultimate.csv')
+    parser.add_argument("--tag-path", help="set path to 'clean' tags database (defaults to path on Boden)", default='/srv/data/urop/clean_lastfm.db')
+    parser.add_argument("--tag-path-multi", help="set path to multiple 'clean' tags databases", nargs='+')
     parser.add_argument("--mels", help="set num of mels to use to encode audio as log-mel-spectrogram, defaults to 128", type=int, default=128)
     parser.add_argument("--sr", help="set sample rate to use to encode audio, defaults to 16kHz", type=int, default=16000)
     parser.add_argument("-n", "--num-files", help="number of files to split the data into, defaults to 100", type=int, default=100)
@@ -309,8 +309,11 @@ if __name__ == '__main__':
     mode.add_argument("-i", "--start-stop", help="specify which interval of files to process (inclusive, starts from 1), use in combination with --n-tfrecords, supply as START STOP", type=int, nargs=2)
 
     args = parser.parse_args()
+
+    if args.tag_path_multi:
+        args.tag_path = os.path.commonpath(args.tag_path_multi) # tag_paths is interpreted as a root directory when multiple databases are specified
     
-    # set seed in case interval is specified, in order to enable parallel execution
+    # set seed in order to enable parallel execution
     if args.start_stop:
         np.random.seed(1)
 

--- a/preprocessing.py
+++ b/preprocessing.py
@@ -62,7 +62,7 @@ from lastfm import LastFm2Pandas
 
 from utils import MyProgbar
 
-def process_array(array, audio_format, sr_in, sr_out = 16000, n_mels = 96):
+def process_array(array, audio_format, sr_in, sr_out = 16000, num_mels = 96):
     ''' Processesing array and applying desired audio format 
     
     The array is processed by the following steps:
@@ -84,7 +84,7 @@ def process_array(array, audio_format, sr_in, sr_out = 16000, n_mels = 96):
     sr_out: int
         The sample rate of the output processed audio.
 
-    n_mels: int
+    num_mels: int
         The number of mels in the mel-spectrogram.
 
     Returns
@@ -101,7 +101,7 @@ def process_array(array, audio_format, sr_in, sr_out = 16000, n_mels = 96):
     array = librosa.resample(array, sr_in, sr_out)
     
     if audio_format == "log-mel-spectrogram":
-        array = librosa.core.power_to_db(librosa.feature.melspectrogram(array, sr_out, n_mels=n_mels))
+        array = librosa.core.power_to_db(librosa.feature.melspectrogram(array, sr_out, num_mels=num_mels))
     
     return array
 
@@ -184,7 +184,7 @@ def get_example(array, tid, encoded_tags):
 
     return tf.train.Example(features=tf.train.Features(feature=feature_dict))
 
-def save_example_to_tfrecord(df, output_path, audio_format, root_dir, tag_path, sample_rate=16000, n_mels=96, multitag=False, verbose=False):
+def save_example_to_tfrecord(df, output_path, audio_format, root_dir, tag_path, sample_rate=16000, num_mels=96, multitag=False, verbose=False):
     ''' Creates and saves a TFRecord file.
 
     Parameters
@@ -208,7 +208,7 @@ def save_example_to_tfrecord(df, output_path, audio_format, root_dir, tag_path, 
     sample_rate: int
         The sample rate to use when serializing the audio.
 
-    n_mels: int
+    num_mels: int
         The number of mels in the mel-spectrogram.
     
     multitag: list
@@ -270,7 +270,7 @@ def save_example_to_tfrecord(df, output_path, audio_format, root_dir, tag_path, 
                 unsampled_audio = {'array': array, 'sr': sr}
 
             # resample audio array into 'sample_rate' and convert into 'audio_format'
-            processed_array = process_array(unsampled_audio['array'], audio_format, sr_in=unsampled_audio['sr'], sr_out=sample_rate, n_mels=n_mels)
+            processed_array = process_array(unsampled_audio['array'], audio_format, sr_in=unsampled_audio['sr'], sr_out=sample_rate, num_mels=num_mels)
             
             # load the tf.Example
             example = get_example(processed_array, tid, encoded_tags)
@@ -347,7 +347,7 @@ if __name__ == '__main__':
             save_example_to_tfrecord(df, base_name + filename[i] + filename_suffix, audio_format=args.format, 
                                      root_dir=args.root_dir, tag_path=args.tag_path, 
                                      multitag=args.tag_path_multi,
-                                     sample_rate=args.sr, n_mels=args.mels,
+                                     sample_rate=args.sr, num_mels=args.mels,
                                      verbose=args.verbose)
 
     # otherwise, save to args.num_files equal-sized files
@@ -364,7 +364,7 @@ if __name__ == '__main__':
                 save_example_to_tfrecord(df_slice, filename, audio_format=args.format, 
                                         root_dir=args.root_dir, tag_path=args.tag_path, 
                                         multitag=args.tag_path_multi,
-                                        sample_rate=args.sr, n_mels=args.mels,
+                                        sample_rate=args.sr, num_mels=args.mels,
                                         verbose=args.verbose)
 
             # the last file will need to be dealt with separately, as it will have a slightly bigger size than the others (due to rounding errors)
@@ -378,7 +378,7 @@ if __name__ == '__main__':
                 save_example_to_tfrecord(df_slice, filename, audio_format=args.format, 
                                         root_dir=args.root_dir, tag_path=args.tag_path, 
                                         multitag=args.tag_path_multi,
-                                        sample_rate=args.sr, n_mels=args.mels,
+                                        sample_rate=args.sr, num_mels=args.mels,
                                         verbose=args.verbose)
         
         # otherwise, create all files at once
@@ -392,7 +392,7 @@ if __name__ == '__main__':
                 save_example_to_tfrecord(df_slice, filename, audio_format=args.format, 
                                         root_dir=args.root_dir, tag_path=args.tag_path, 
                                         multitag=args.tag_path_multi,
-                                        sample_rate=args.sr, n_mels=args.mels,
+                                        sample_rate=args.sr, num_mels=args.mels,
                                         verbose=args.verbose)
 
             # the last file will need to be dealt with separately, as it will have a slightly bigger size than the others (due to rounding errors)
@@ -404,5 +404,5 @@ if __name__ == '__main__':
             save_example_to_tfrecord(df_slice, filename, audio_format=args.format, 
                                         root_dir=args.root_dir, tag_path=args.tag_path, 
                                         multitag=args.tag_path_multi,
-                                        sample_rate=args.sr, n_mels=args.mels,
+                                        sample_rate=args.sr, num_mels=args.mels,
                                         verbose=args.verbose)

--- a/preprocessing.py
+++ b/preprocessing.py
@@ -318,7 +318,7 @@ if __name__ == '__main__':
 
     args = parser.parse_args()
     
-    # set seed in case interval is specified in order to enable parallel execution
+    # set seed in case interval is specified, in order to enable parallel execution
     if args.start_stop:
         np.random.seed(1)
 
@@ -332,13 +332,9 @@ if __name__ == '__main__':
     if not os.path.isdir(args.output):
         os.makedirs(args.output)
 
-    # create base_name variable, for naming the .tfrecord files
-    if args.format == "log-mel-spectrogram":
-        base_name = os.path.join(args.output, args.format + "_")
-    else:
-        base_name = os.path.join(args.output, "waveform_")
+    base_name = os.path.join(args.output, args.format + "_") # to name the output .tfrecord files
     
-    # if split is specified, save to three files (for training, testing and validating)
+    # if split is specified, save to three files (for training, validating and testing)
     if args.split: 
         # scaling up split
         tot = len(df)

--- a/preprocessing.py
+++ b/preprocessing.py
@@ -101,7 +101,7 @@ def process_array(array, audio_format, sr_in, sr_out = 16000, num_mels = 96):
     array = librosa.resample(array, sr_in, sr_out)
     
     if audio_format == "log-mel-spectrogram":
-        array = librosa.core.power_to_db(librosa.feature.melspectrogram(array, sr_out, num_mels=num_mels))
+        array = librosa.core.power_to_db(librosa.feature.melspectrogram(array, sr_out, n_mels=num_mels))
     
     return array
 
@@ -291,7 +291,7 @@ if __name__ == '__main__':
     parser = argparse.ArgumentParser()
     parser.add_argument("format", choices=["waveform", "log-mel-spectrogram"], help="output format of audio")
     parser.add_argument("output", help="directory to save .tfrecord files in")
-    parser.add_argument("--root-dir", help="set path to directory containing the .npz files (defaults to path on Boden)", default='/srv/data/msd/7digital/')
+    parser.add_argument("--root-dir", help="set path to directory containing the .npz or .mp3 files (defaults to path on Boden)", default='/srv/data/msd/7digital/')
     parser.add_argument("--csv-path", help="set path to .csv file (defaults to path on Boden)", default='/srv/data/urop/ultimate.csv')
     parser.add_argument("--tag-path", help="set path to 'clean' tags database (defaults to path on Boden)", default='/srv/data/urop/clean_lastfm.db')
     parser.add_argument("--tag-path-multi", help="set path to multiple 'clean' tags databases", nargs='+')

--- a/preprocessing.py
+++ b/preprocessing.py
@@ -177,14 +177,14 @@ def get_example(array, tid, encoded_tags):
     feature_dict = {'audio': _float_feature(array.flatten()), 'tid': _bytes_feature(bytes(tid, 'utf8'))} 
 
     if len(encoded_tags.shape) == 1:
-        feature_dict['tag'] = _int64_feature(encoded_tags)
+        feature_dict['tags'] = _int64_feature(encoded_tags)
     else:
         for i, encoded_tags in enumerate(encoded_tags):
-            feature_dict['tag_' + str(i)] = _int64_feature(encoded_tags)
+            feature_dict['tags_' + str(i)] = _int64_feature(encoded_tags)
 
     return tf.train.Example(features=tf.train.Features(feature=feature_dict))
 
-def save_example_to_tfrecord(df, output_path, audio_format, root_dir, tag_path, sample_rate=16000, n_mels=96, multitag=None, verbose=True):
+def save_example_to_tfrecord(df, output_path, audio_format, root_dir, tag_path, sample_rate=16000, n_mels=96, multitag=False, verbose=False):
     ''' Creates and saves a TFRecord file.
 
     Parameters
@@ -212,17 +212,13 @@ def save_example_to_tfrecord(df, output_path, audio_format, root_dir, tag_path, 
         The number of mels in the mel-spectrogram.
     
     multitag: list
-        If not None, encode multiple tags at the same time (provide as list of filenames; feature names will be 'tag-0', 'tag-1' etc.)
+        If True, encode multiple tags at the same time (provide as list of filenames; feature names will be 'tags-0', 'tags-1' etc.)
 
     verbose: bool
         If True, print progress.
     '''
 
     with tf.io.TFRecordWriter(output_path) as writer:
-        start = time.time()
-        start_loop = time.time()
-
-        # tags encoded outside the loop for efficiency
         if not multitag:
             fm = LastFm(tag_path)
             n_tags = len(fm.get_tag_nums())

--- a/preprocessing.py
+++ b/preprocessing.py
@@ -249,9 +249,9 @@ def save_example_to_tfrecord(df, output_path, audio_format, root_dir, tag_path, 
 
             # encode tags
             if not multitag:
-                encoded_tags = get_encoded_tags(tid, fm, n_tags)
+                encoded_tags = get_encoded_tags(fm, tid, n_tags)
             else:
-                encoded_tags = np.array([get_encoded_tags(tid, fm, n_tags) for fm in fm]) # convert to ndarray to ensure consistency with one-dimensional case
+                encoded_tags = np.array([get_encoded_tags(fm, tid, n_tags) for fm in fm]) # convert to ndarray to ensure consistency with one-dimensional case
             
             # skip tracks which dont have any "clean" tags    
             if encoded_tags.size == 0:
@@ -310,8 +310,11 @@ if __name__ == '__main__':
 
     args = parser.parse_args()
 
+    # sanity check
     if args.tag_path_multi:
+        args.tag_path_multi = [os.path.expanduser(path) for path in args.tag_path_multi]
         args.tag_path = os.path.commonpath(args.tag_path_multi) # tag_paths is interpreted as a root directory when multiple databases are specified
+        args.tag_path_multi = [os.path.relpath(path, start=args.tag_path) for path in args.tag_path_multi]
     
     # set seed in order to enable parallel execution
     if args.start_stop:
@@ -358,7 +361,7 @@ if __name__ == '__main__':
             start, stop = args.start_stop
             for num_file in range(start-1, stop):
                 filename = base_name + str(num_file+1) + ".tfrecord"
-                print("Now writing to: " + filename)
+                print("Writing to: " + filename)
                 # obtain the df slice corresponding to current file
                 df_slice = df[num_file*len(df)//args.num_files:(num_file+1)*len(df)//args.num_files]
                 # create and save
@@ -372,7 +375,7 @@ if __name__ == '__main__':
             if stop >= args.num_files:
                 stop = args.num_files-1
                 filename = base_name + str(args.num_files) + ".tfrecord"
-                print("Now writing to: " + filename)
+                print("Writing to: " + filename)
                 # obtain the df slice corresponding the last file
                 df_slice = df.loc[(args.num_files-1)*len(df)//args.num_files:]
                 # create and save to the .tfrecord file
@@ -386,7 +389,7 @@ if __name__ == '__main__':
         else:
             for num_file in range(args.num_files - 1):
                 filename = base_name + str(num_file+1) + ".tfrecord"
-                print("Now writing to: " + filename)
+                print("Writing to: " + filename)
                 # obtain the df slice corresponding to current file
                 df_slice = df[num_file*len(df)//args.num_files:(num_file+1)*len(df)//args.num_files]
                 # create and save to the .tfrecord file
@@ -398,7 +401,7 @@ if __name__ == '__main__':
 
             # the last file will need to be dealt with separately, as it will have a slightly bigger size than the others (due to rounding errors)
             filename = base_name + str(args.num_files) + ".tfrecord"
-            print("Now writing to: " + filename)
+            print("Writing to: " + filename)
             # obtain the df slice corresponding to the last file
             df_slice = df.loc[(args.num_files-1)*len(df)//args.num_files:]
             # create and save to the .tfrecord file

--- a/projectname_input.py
+++ b/projectname_input.py
@@ -273,7 +273,7 @@ def _window_log_mel_spectrogram(features_dict, sample_rate, window_size=15, rand
 def _spect_normalization(features_dict):
     ''' Normalizes the log-mel-spectrograms within a batch. '''
 
-    mean, variance = tf.nn.moments(features_dict['audio'], axes=[1,2], keep_dims=True)
+    mean, variance = tf.nn.moments(features_dict['audio'], axes=[1,2], keepdims=True)
     features_dict['audio'] = tf.nn.batch_normalization(features_dict['audio'], mean, variance, offset = 0, scale = 1, variance_epsilon = .000001)
     return features_dict
 

--- a/projectname_input.py
+++ b/projectname_input.py
@@ -454,4 +454,9 @@ def generate_datasets_from_dir(tfrecords_dir, audio_format, split=None, which_sp
         if file.endswith(".tfrecord") and file.split('_')[0] == audio_format:
             tfrecords.append(os.path.abspath(os.path.join(tfrecords_dir, file)))
 
-    return generate_datasets(tfrecords, audio_format, split, which_split, sample_rate, batch_size, cycle_length, shuffle, buffer_size, window_size, random, with_tids, with_tags, merge_tags, num_tags, repeat, as_tuple)
+    return generate_datasets(tfrecords, audio_format, split=split, whici_split=which_split, 
+                             sample_rate=sample_rate, batch_size=batch_size, cycle_length=cycle_length, 
+                             shuffle=shuffle, buffer_size=buffer_size, 
+                             window_size=window_size, random=random, 
+                             with_tids=with_tids, with_tags=with_tags, merge_tags=merge_tags, num_tags=num_tags, 
+                             repeat=repeat, as_tuple=as_tuple)

--- a/projectname_input.py
+++ b/projectname_input.py
@@ -371,10 +371,15 @@ def generate_datasets(tfrecords, audio_format, split=None, which_split=None, sam
 
     # check if multiple databases have been provided
     if num_tags_databases == 1:
+        # add standard feature 'tags'
         AUDIO_FEATURES_DESCRIPTION['tags'] = tf.io.FixedLenFeature((num_tags, ), tf.int64)
     else:
+        # add feature 'tags_i' for each i-th tags database provided
         for i in range(num_tags_databases):
             AUDIO_FEATURES_DESCRIPTION['tags_' + str(i)] = tf.io.FixedLenFeature((num_tags, ), tf.int64)
+        
+        # if default_tags_db has not been provided, default to 0 (otherwise as_tuple would raise error)
+        default_tags_db = default_tags_db or 0
 
     assert audio_format in ('waveform', 'log-mel-spectrogram') , 'invalid audio format'
     
@@ -526,5 +531,5 @@ def generate_datasets_from_dir(tfrecords_dir, audio_format, split=None, which_sp
                              sample_rate=sample_rate, num_mels=num_mels, 
                              batch_size=batch_size, cycle_length=cycle_length, shuffle=shuffle, buffer_size=buffer_size, 
                              window_size=window_size, random=random, 
-                             with_tids=with_tids, with_tags=with_tags, merge_tags=merge_tags, num_tags=num_tags, num_tags_databases=num_tags_databases, 
+                             with_tids=with_tids, with_tags=with_tags, merge_tags=merge_tags, num_tags=num_tags, num_tags_databases=num_tags_databases, default_tags_db=default_tags_db,
                              repeat=repeat, as_tuple=as_tuple)

--- a/projectname_input.py
+++ b/projectname_input.py
@@ -252,7 +252,7 @@ def _batch_tuplification(features_dict):
     ''' Transforms a batch into (audio, tags) tuples, ready for training or evaluation with Keras. '''
     return (features_dict['audio'], features_dict['tags'])
 
-def generate_datasets(tfrecords, audio_format, split=None, which_split=None, sample_rate=16000, batch_size=32, cycle_length=2, shuffle=True, buffer_size=10000, window_size=15, random=False, with_tids=None, with_tags=None, merge_tags=None, num_tags=155, repeat=None, as_tuple=True):
+def generate_datasets(tfrecords, audio_format, split=None, which_split=None, sample_rate=16000, batch_size=32, cycle_length=1, shuffle=True, buffer_size=10000, window_size=15, random=False, with_tids=None, with_tags=None, merge_tags=None, num_tags=155, repeat=None, as_tuple=True):
     ''' Reads the TFRecords and produces a list tf.data.Dataset objects ready for training/evaluation.
     
     Parameters:
@@ -323,7 +323,7 @@ def generate_datasets(tfrecords, audio_format, split=None, which_split=None, sam
     tfrecords = np.vectorize(lambda x: os.path.abspath(os.path.expanduser(x)))(tfrecords) # fix issues with relative paths in input list
 
     if split is not None:
-        assert len(tfrecords) >= sum(split) , 'too few .tfrecord files to apply split'
+        assert tfrecords.size >= sum(split) , 'too few .tfrecord files to apply split'
         split = np.cumsum(split)
         tfrecords_split = np.split(tfrecords, split)
         tfrecords_split = tfrecords_split[:-1] # discard last 'empty' split
@@ -333,7 +333,7 @@ def generate_datasets(tfrecords, audio_format, split=None, which_split=None, sam
     datasets = []
 
     for files_list in tfrecords_split:
-        if len(files_list) > 1: # read files in parallel (number of parallel threads specified by cycle_length)
+        if files_list.size > 1: # read files in parallel (number of parallel threads specified by cycle_length)
             files = tf.data.Dataset.from_tensor_slices(files_list)
             dataset = files.interleave(tf.data.TFRecordDataset, cycle_length=cycle_length, block_length=1, num_parallel_calls=tf.data.experimental.AUTOTUNE)
         else:
@@ -394,7 +394,7 @@ def generate_datasets(tfrecords, audio_format, split=None, which_split=None, sam
     else:
         return datasets
 
-def generate_datasets_from_dir(tfrecords_dir, audio_format, split=None, which_split=None, sample_rate=16000, batch_size=32, cycle_length=2, shuffle=True, buffer_size=10000, window_size=15, random=False, with_tids=None, with_tags=None, merge_tags=None, num_tags=155, repeat=1, as_tuple=True):
+def generate_datasets_from_dir(tfrecords_dir, audio_format, split=None, which_split=None, sample_rate=16000, batch_size=32, cycle_length=1, shuffle=True, buffer_size=10000, window_size=15, random=False, with_tids=None, with_tags=None, merge_tags=None, num_tags=155, repeat=1, as_tuple=True):
     ''' Reads the TFRecords from the input directory and produces a list tf.data.Dataset objects ready for training/evaluation.
     
     Parameters:

--- a/projectname_input.py
+++ b/projectname_input.py
@@ -77,7 +77,7 @@ def _merge(features_dict, tags):
     features_dict: dict
         Dict of features (as provided by .map).
 
-    merge_tags: list or list-like
+    tags: list or list-like
         List of lists of tags to be merged. Writes 1 for all tags in the hot-encoded vector whenever at least one tag of the list is present.
 
     Examples
@@ -88,22 +88,32 @@ def _merge(features_dict, tags):
     >>> _merge(features, merge_tags=[[0, 1], [3, 4]])
     features['tags']: [1, 1, 1, 0, 0] 
     '''
-    tags = tf.dtypes.cast(tags, tf.int64)
-    n_tags = tf.cast(tf.shape(features_dict['tags']), tf.int64)
 
-    feature_tags = tf.dtypes.cast(features_dict['tags'], tf.bool)
+    tags_databases = len(features_dict) - 2 # check if multiple databases have been provided
     
+    tags = tf.dtypes.cast(tags, tf.int64)
     idxs = tf.subtract(tf.reshape(tf.sort(tags), [-1,1]), tf.constant(1, dtype=tf.int64))
     vals = tf.constant(1, dtype=tf.int64, shape=[len(tags)])
     tags = tf.SparseTensor(indices=idxs, values=vals, dense_shape=n_tags)
     tags = tf.sparse.to_dense(tags)
     tags = tf.dtypes.cast(tags, tf.bool)
-    # if at least one of the feature tags is in the current 'tags' list, write True in the bool-hot-encoded vector for all tags in 'tags'; otherwise, leave feature tags as they are
-    features_dict['tags'] = tf.where(tf.math.reduce_any(tags & feature_tags), tags | feature_tags, feature_tags)
-    features_dict['tags'] = tf.cast(features_dict['tags'], tf.int64)
+    
+    def _fn(tag_str): # avoid repetitions of code by defining a handy function
+        n_tags = tf.cast(tf.shape(features_dict[tag_str]), tf.int64)
+        feature_tags = tf.dtypes.cast(features_dict[tag_str], tf.bool)
+        # if at least one of the feature tags is in the current 'tags' list, write True in the bool-hot-encoded vector for all tags in 'tags'; otherwise, leave feature tags as they are
+        features_dict[tag_str] = tf.where(tf.math.reduce_any(tags & feature_tags), tags | feature_tags, feature_tags)
+        features_dict[tag_str] = tf.cast(features_dict[tag_str], tf.int64)
+
+    if tags_databases > 1:
+        for i in range(tags_databases):
+            _fn('tags_' + str(i))
+    else:
+        _fn('tags')
+
     return features_dict
 
-def _tag_filter(features_dict, tags):
+def _tag_filter(features_dict, tags, which_tags=None):
     ''' Removes unwanted tids from the dataset based on given tags (use with tf.data.Dataset.filter).
     
     Parameters
@@ -113,11 +123,21 @@ def _tag_filter(features_dict, tags):
 
     tags: list or list-like
         List containing tag idxs (as int) to be "allowed" in the output dataset.
-    '''
-    tags = tf.dtypes.cast(tags, dtype=tf.int64)
-    n_tags = tf.cast(tf.shape(features_dict['tags']), tf.int64)
 
-    feature_tags = tf.math.equal(tf.unstack(features_dict['tags']), tf.constant(1, dtype=tf.int64)) # bool tensor where True/False correspond to has/doesn't have tag
+    which_tags: int
+        If not None, specifies the database to filter on (when multiple databases are provided).
+    '''
+
+    tags = tf.dtypes.cast(tags, dtype=tf.int64)
+    
+    if which_tags is None:
+        dict_key = 'tags'
+    else:
+        assert isinstance(which_tags, int), 'which_tags must be an integer'
+        dict_key = 'tags_' + str(which_tags)
+    
+    n_tags = tf.cast(tf.shape(features_dict[dict_key]), tf.int64)
+    feature_tags = tf.math.equal(tf.unstack(features_dict[dict_key]), tf.constant(1, dtype=tf.int64)) # bool tensor where True/False correspond to has/doesn't have tag
     idxs = tf.subtract(tf.reshape(tf.sort(tags), [-1,1]), tf.constant(1, dtype=tf.int64))
     vals = tf.constant(1, dtype=tf.int64, shape=[len(tags)])
     tags_mask = tf.SparseTensor(indices=idxs, values=vals, dense_shape=n_tags)
@@ -137,6 +157,7 @@ def _tid_filter(features_dict, tids):
     tids: list or list-like
         List containing tids (as strings) to be "allowed" in the output dataset.
     '''
+
     tids = tf.constant(tids, tf.string)
     return tf.math.reduce_any(tf.math.equal(tids, features_dict['tid']))
 
@@ -151,9 +172,21 @@ def _tag_filter_hotenc_mask(features_dict, tags):
     tags: list or list-like
         List containing tag idxs used for filtering with _tag_filter.
     '''
+    
+    tags_databases = len(features_dict) - 2 # check if multiple databases have been provided
+    
     tags = tf.dtypes.cast(tags, dtype=tf.int64)
     idxs = tf.subtract(tf.sort(tags), tf.constant(1, dtype=tf.int64))
-    features_dict['tags'] = tf.gather(features_dict['tags'], idxs)
+
+    def _fn(tag_str): # avoid repetitions of code by defining a handy function
+        features_dict[tag_str] = tf.gather(features_dict[tag_str], idxs)
+    
+    if tags_databases > 1:
+        for i in range(tags_databases):
+            _fn('tags_' + str(i))
+    else:
+        _fn('tags')
+
     return features_dict
 
 def _window_waveform(features_dict, sample_rate, window_size=15, random=False):
@@ -248,11 +281,25 @@ def _batch_normalization(features_dict):
     features_dict['audio'] = tf.nn.batch_normalization(features_dict['audio'], mean, variance, offset = 0, scale = 1, variance_epsilon = .000001)
     return features_dict
 
-def _batch_tuplification(features_dict):
-    ''' Transforms a batch into (audio, tags) tuples, ready for training or evaluation with Keras. '''
-    return (features_dict['audio'], features_dict['tags'])
+def _batch_tuplification(features_dict, which_tags=None):
+    ''' Transforms a batch into (audio, tags) tuples, ready for training or evaluation with Keras. 
+    
+    Parameters
+    ----------
+    features_dict: dict
+        Dict of features (as provided by .filter).
 
-def generate_datasets(tfrecords, audio_format, split=None, which_split=None, sample_rate=16000, batch_size=32, cycle_length=1, shuffle=True, buffer_size=10000, window_size=15, random=False, with_tids=None, with_tags=None, merge_tags=None, num_tags=155, repeat=None, as_tuple=True):
+    which_tags: int
+        If not None, specifies the database to use (when multiple databases are provided).
+    '''
+    
+    if which_tags is None:
+        return (features_dict['audio'], features_dict['tags'])
+    else:
+        assert isinstance(which_tags, int), 'which_tags must be an integer'
+        return (features_dict['audio'], features_dict['tags_' + str(which_tags)])
+
+def generate_datasets(tfrecords, audio_format, split=None, which_split=None, sample_rate=16000, n_mels=96, batch_size=32, cycle_length=1, shuffle=True, buffer_size=10000, window_size=15, random=False, with_tids=None, with_tags=None, merge_tags=None, n_tags=155, n_tags_databases=1, default_tags_db=None, repeat=None, as_tuple=True):
     ''' Reads the TFRecords and produces a list tf.data.Dataset objects ready for training/evaluation.
     
     Parameters:
@@ -289,9 +336,18 @@ def generate_datasets(tfrecords, audio_format, split=None, which_split=None, sam
 
     random: bool
         Specifies how the window is to be extracted. If True, slices the window randomly (default is pick from the middle).
+
+    n_mels: int
+        The number of mels in the mel-spectrogram.
     
-    num_tags: int
-        Specifies the total number of tags.
+    n_tags: int
+        The total number of tags.
+    
+    n_tags_databases: int
+        The total number of tags databases used.
+    
+    default_tags_db: int
+        Specifies the tags database to use when filtering tags or converting into tuple (if multiple databases are provided).
 
     with_tids: list
         If not None, contains the tids to be trained on.
@@ -309,13 +365,18 @@ def generate_datasets(tfrecords, audio_format, split=None, which_split=None, sam
         If True, discards tid's and transforms features into (audio, tags) tuples.
     '''
 
-    AUDIO_SHAPE = {'waveform': (-1, ), 'log-mel-spectrogram': (96, -1)} # set audio tensors dense shape
+    assert isinstance(n_mels, int), 'n_mels must be an integer'
 
-    AUDIO_FEATURES_DESCRIPTION = {
-        'audio': tf.io.VarLenFeature(tf.float32),
-        'tid': tf.io.FixedLenFeature((), tf.string),
-        'tags': tf.io.FixedLenFeature((num_tags, ), tf.int64)
-    }
+    AUDIO_SHAPE = {'waveform': (-1, ), 'log-mel-spectrogram': (n_mels, -1)} # set audio tensors dense shape
+
+    AUDIO_FEATURES_DESCRIPTION = {'audio': tf.io.VarLenFeature(tf.float32), 'tid': tf.io.FixedLenFeature((), tf.string)} # tags will be added just below
+
+    # check if multiple databases have been provided
+    if n_tags_databases == 1:
+        AUDIO_FEATURES_DESCRIPTION['tags'] = tf.io.FixedLenFeature((n_tags, ), tf.int64)
+    else:
+        for i in range(n_tags_databases):
+            AUDIO_FEATURES_DESCRIPTION['tags_' + str(i)] = tf.io.FixedLenFeature((n_tags, ), tf.int64)
 
     assert audio_format in ('waveform', 'log-mel-spectrogram') , 'invalid audio format'
     
@@ -352,10 +413,10 @@ def generate_datasets(tfrecords, audio_format, split=None, which_split=None, sam
                 for tags in merge_tags:
                       dataset = dataset.map(lambda x: _merge(x, tags))
                     
-            dataset = dataset.filter(lambda x: _tag_filter(x, with_tags)).map(lambda y: _tag_filter_hotenc_mask(y, with_tags))
+            dataset = dataset.filter(lambda x: _tag_filter(x, tags=with_tags, which_tags=default_tags_db)).map(lambda y: _tag_filter_hotenc_mask(y, tags=with_tags))
                         
         if with_tids is not None:
-            dataset = dataset.filter(lambda x: _tid_filter(x, with_tids))
+            dataset = dataset.filter(lambda x: _tid_filter(x, tids=with_tids))
         
         # slice into audio windows
         
@@ -375,7 +436,7 @@ def generate_datasets(tfrecords, audio_format, split=None, which_split=None, sam
         
         # convert features from dict into tuple
         if as_tuple:
-            dataset = dataset.map(_batch_tuplification, num_parallel_calls=tf.data.experimental.AUTOTUNE)
+            dataset = dataset.map(lambda x: _batch_tuplification(x, which_tags=default_tags_db), num_parallel_calls=tf.data.experimental.AUTOTUNE)
 
         dataset = dataset.repeat(repeat)
         dataset = dataset.prefetch(buffer_size=tf.data.experimental.AUTOTUNE) # performance optimization
@@ -394,7 +455,7 @@ def generate_datasets(tfrecords, audio_format, split=None, which_split=None, sam
     else:
         return datasets
 
-def generate_datasets_from_dir(tfrecords_dir, audio_format, split=None, which_split=None, sample_rate=16000, batch_size=32, cycle_length=1, shuffle=True, buffer_size=10000, window_size=15, random=False, with_tids=None, with_tags=None, merge_tags=None, num_tags=155, repeat=1, as_tuple=True):
+def generate_datasets_from_dir(tfrecords_dir, audio_format, split=None, which_split=None, sample_rate=16000, n_mels=96, batch_size=32, cycle_length=1, shuffle=True, buffer_size=10000, window_size=15, random=False, with_tids=None, with_tags=None, merge_tags=None, n_tags=155, n_tags_databases=1, default_tags_db=None, repeat=1, as_tuple=True):
     ''' Reads the TFRecords from the input directory and produces a list tf.data.Dataset objects ready for training/evaluation.
     
     Parameters:
@@ -429,8 +490,17 @@ def generate_datasets_from_dir(tfrecords_dir, audio_format, split=None, which_sp
     random: bool
         Specifies how the window is to be extracted. If True, slices the window randomly (default is pick from the middle).
     
-    num_tags: int
-        Specifies the total number of tags.
+    n_mels: int
+        The number of mels in the mel-spectrogram.
+    
+    n_tags: int
+        The total number of tags.
+    
+    n_tags_databases: int
+        The total number of tags databases used.
+    
+    default_tags_db: int
+        Specifies the tags database to use when filtering tags or converting into tuple (if multiple databases are provided).
 
     with_tids: list
         If not None, contains the tids to be trained on.
@@ -454,9 +524,9 @@ def generate_datasets_from_dir(tfrecords_dir, audio_format, split=None, which_sp
         if file.endswith(".tfrecord") and file.split('_')[0] == audio_format:
             tfrecords.append(os.path.abspath(os.path.join(tfrecords_dir, file)))
 
-    return generate_datasets(tfrecords, audio_format, split=split, whici_split=which_split, 
-                             sample_rate=sample_rate, batch_size=batch_size, cycle_length=cycle_length, 
-                             shuffle=shuffle, buffer_size=buffer_size, 
+    return generate_datasets(tfrecords, audio_format, split=split, which_split=which_split, 
+                             sample_rate=sample_rate, n_mels=n_mels, 
+                             batch_size=batch_size, cycle_length=cycle_length, shuffle=shuffle, buffer_size=buffer_size, 
                              window_size=window_size, random=random, 
-                             with_tids=with_tids, with_tags=with_tags, merge_tags=merge_tags, num_tags=num_tags, 
+                             with_tids=with_tids, with_tags=with_tags, merge_tags=merge_tags, n_tags=n_tags, n_tags_databases=n_tags_databases, 
                              repeat=repeat, as_tuple=as_tuple)

--- a/projectname_input.py
+++ b/projectname_input.py
@@ -365,8 +365,6 @@ def generate_datasets(tfrecords, audio_format, split=None, which_split=None, sam
         If True, discards tid's and transforms features into (audio, tags) tuples.
     '''
 
-    assert isinstance(num_mels, int), 'num_mels must be an integer'
-
     AUDIO_SHAPE = {'waveform': (-1, ), 'log-mel-spectrogram': (num_mels, -1)} # set audio tensors dense shape
 
     AUDIO_FEATURES_DESCRIPTION = {'audio': tf.io.VarLenFeature(tf.float32), 'tid': tf.io.FixedLenFeature((), tf.string)} # tags will be added just below

--- a/utils.py
+++ b/utils.py
@@ -1,14 +1,16 @@
-# see https://stackoverflow.com/questions/13249415/how-to-implement-custom-indentation-when-pretty-printing-with-the-json-module
-
 from _ctypes import PyObj_FromPtr
 import json
 import re
+import sys
+import time
 
-class NoIndent(object): # value wrapper
+import numpy as np
+
+class WithoutIndent(object): # value wrapper
     def __init__(self, value):
         self.value = value
 
-class MyEncoder(json.JSONEncoder):
+class MyEncoder(json.JSONEncoder): # see https://stackoverflow.com/questions/13249415/how-to-implement-custom-indentation-when-pretty-printing-with-the-json-module
     FORMAT_SPEC = '@@{}@@'
     regex = re.compile(FORMAT_SPEC.format(r'(\d+)'))
 
@@ -35,3 +37,183 @@ class MyEncoder(json.JSONEncoder):
             json_repr = json_repr.replace(
                             '"{}"'.format(format_spec.format(id)), json_obj_repr)
         return json_repr
+
+class MyProgbar(object):
+    ''' Displays a progress bar.
+
+    Parameters
+    ----------
+    target: int 
+        Total number of steps expected, None if unknown.
+        
+    width: int 
+        Progress bar width on screen.
+    
+    verbose: int
+        Verbosity mode, 0 (silent), 1 (verbose), 2 (semi-verbose)
+    
+    stateful_metrics: list
+        Iterable of string names of metrics that should *not* be averaged over time. 
+        Metrics in this list will be displayed as-is. 
+        All others will be averaged by the progbar before display.
+
+    interval: float 
+        Minimum visual progress update interval (in seconds).
+    
+    unit_name: str
+        Display name for step counts (usually "step" or "sample").
+    '''
+
+    def __init__(self, target, width=30, verbose=1, interval=0.05, stateful_metrics=None, unit_name='step'):
+        self.target = target
+        self.width = width
+        self.verbose = verbose
+        self.interval = interval
+        self.unit_name = unit_name
+        if stateful_metrics:
+            self.stateful_metrics = set(stateful_metrics)
+        else:
+            self.stateful_metrics = set()
+        self._dynamic_display = ((hasattr(sys.stdout, 'isatty') and sys.stdout.isatty()) or 'ipykernel' in sys.modules or 'posix' in sys.modules)
+        self._total_width = 0
+        self._seen_so_far = 0
+        self._values = {}
+        self._values_order = []
+        self._start = time.time()
+        self._last_update = 0
+
+    def update(self, current, values=None):
+        ''' Updates the progress bar.
+
+        Parameters
+        ----------
+        current: int
+            Index of current step.
+        
+        values: list of tuples (name, value_for_last_step)
+            If 'name' is in 'stateful_metrics', 'value_for_last_step' will be displayed as-is.
+            Otherwise, an average of the metric over time will be displayed.
+        '''
+
+        values = values or []
+        for k, v in values:
+            if k not in self._values_order:
+                self._values_order.append(k)
+            if k not in self.stateful_metrics:
+                if k not in self._values:
+                    self._values[k] = [v * (current - self._seen_so_far), current - self._seen_so_far]
+                else:
+                    self._values[k][0] += v * (current - self._seen_so_far)
+                    self._values[k][1] += (current - self._seen_so_far)
+            else:
+                self._values[k] = [v, 1]
+        self._seen_so_far = current
+
+        now = time.time()
+        info = ' - %.0fs' % (now - self._start)
+        if self.verbose == 1:
+            if (now - self._last_update < self.interval and
+                    self.target is not None and current < self.target):
+                return
+
+            prev_total_width = self._total_width
+            if self._dynamic_display:
+                sys.stdout.write('\b' * prev_total_width)
+                sys.stdout.write('\r')
+            else:
+                sys.stdout.write('\n')
+
+            if self.target is not None:
+                numdigits = int(np.log10(self.target)) + 1
+                bar = ('%' + str(numdigits) + 'd/%d [') % (current, self.target)
+                prog = float(current) / self.target
+                prog_width = int(self.width * prog)
+                if prog_width > 0:
+                    bar += ('=' * (prog_width - 1))
+                    if current < self.target:
+                        bar += '>'
+                    else:
+                        bar += '='
+                bar += ('.' * (self.width - prog_width))
+                bar += ']'
+            else:
+                bar = '%7d/Unknown' % current
+
+            self._total_width = len(bar)
+            sys.stdout.write(bar)
+
+            if current:
+                time_per_unit = (now - self._start) / current
+            else:
+                time_per_unit = 0
+            if self.target is not None and current < self.target:
+                eta = time_per_unit * (self.target - current)
+                if eta > 3600:
+                    eta_format = '%d:%02d:%02d' % (eta // 3600, (eta % 3600) // 60, eta % 60)
+                elif eta > 60:
+                    eta_format = '%d:%02d' % (eta // 60, eta % 60)
+                else:
+                    eta_format = '%ds' % eta
+
+                info = ' - ETA: %s' % eta_format
+            else:
+                if time_per_unit >= 1 or time_per_unit == 0:
+                    info += ' %.0fs/%s' % (time_per_unit, self.unit_name)
+                elif time_per_unit >= 1e-3:
+                    info += ' %.0fms/%s' % (time_per_unit * 1e3, self.unit_name)
+                else:
+                    info += ' %.0fus/%s' % (time_per_unit * 1e6, self.unit_name)
+
+            for k in self._values_order:
+                info += ' - %s:' % k
+                if isinstance(self._values[k], list):
+                    avg = np.mean(self._values[k][0] / max(1, self._values[k][1]))
+                    if abs(avg) > 1e-3:
+                        info += ' %.4f' % avg
+                    else:
+                        info += ' %.4e' % avg
+                else:
+                    info += ' %s' % self._values[k]
+
+            self._total_width += len(info)
+            if prev_total_width > self._total_width:
+                info += (' ' * (prev_total_width - self._total_width))
+
+            if self.target is not None and current >= self.target:
+                info += '\n'
+
+            sys.stdout.write(info)
+            sys.stdout.flush()
+
+        elif self.verbose == 2:
+            if self.target is not None and current >= self.target:
+                numdigits = int(np.log10(self.target)) + 1
+                count = ('%' + str(numdigits) + 'd/%d') % (current, self.target)
+                info = count + info
+                for k in self._values_order:
+                    info += ' - %s:' % k
+                    avg = np.mean(self._values[k][0] / max(1, self._values[k][1]))
+                    if avg > 1e-3:
+                        info += ' %.4f' % avg
+                    else:
+                        info += ' %.4e' % avg
+                info += '\n'
+
+                sys.stdout.write(info)
+                sys.stdout.flush()
+
+        self._last_update = now
+
+    def add(self, n, values=None):
+        ''' Updates the progress bar.
+
+        Parameters
+        ----------
+        n: int
+            Index to add to current step.
+        
+        values: list of tuples (name, value_for_last_step)
+            If 'name' is in 'stateful_metrics', 'value_for_last_step' will be displayed as-is.
+            Otherwise, an average of the metric over time will be displayed.
+        '''
+        self.update(self._seen_so_far + n, values)


### PR DESCRIPTION
This PR affects preprocessing.py and projectname_input.py

Changelog: 
1. Multiple databases can now be passed at the same time when creating the TFRecords. In that case, the feature dictionary has the following structure: `{'audio', 'tid', 'tags_0', 'tags_1', 'tags_2'}`.