### PR TITLE
Fix input

### DIFF
--- a/projectname_input.py
+++ b/projectname_input.py
@@ -394,7 +394,7 @@ def generate_datasets(tfrecords, audio_format, split=None, which_split=None, sam
     tfrecords = np.array(tfrecords, dtype=np.unicode) # allow for single str as input
     tfrecords = np.vectorize(lambda x: os.path.abspath(os.path.expanduser(x)))(tfrecords) # fix issues with relative paths in input list
 
-    if split is not None:
+    if split:
         if np.sum(split) == 100:
             split = np.cumsum(split) * len(tfrecords) // 100
         else:

--- a/training.py
+++ b/training.py
@@ -307,7 +307,7 @@ if __name__ == '__main__':
                                                                                 sample_rate=config.sr, batch_size=config.batch, 
                                                                                 cycle_length=config.cycle_len, 
                                                                                 shuffle=config.shuffle, shuffle_buffer_size=config.shuffle_buffer, 
-                                                                                num_tags=config.tot_tags, window_size=config.window_len, window_random=config.window_random, 
+                                                                                num_tags=config.tot_tags, window_length=config.window_len, window_random=config.window_random, 
                                                                                 with_tags=config.tags, merge_tags=config.tags_to_merge)
 
     # set up training strategy

--- a/training.py
+++ b/training.py
@@ -306,8 +306,8 @@ if __name__ == '__main__':
     train_dataset, valid_dataset = projectname_input.generate_datasets_from_dir(args.tfrecords_dir, args.frontend, split=config.split, which_split=(True, True, ) + (False, ) * (len(config.split)-2),
                                                                                 sample_rate=config.sr, batch_size=config.batch, 
                                                                                 cycle_length=config.cycle_len, 
-                                                                                shuffle=config.shuffle, buffer_size=config.shuffle_buffer, 
-                                                                                num_tags=config.tot_tags, window_size=config.window_len, random=config.window_random, 
+                                                                                shuffle=config.shuffle, shuffle_buffer_size=config.shuffle_buffer, 
+                                                                                num_tags=config.tot_tags, window_size=config.window_len, window_random=config.window_random, 
                                                                                 with_tags=config.tags, merge_tags=config.tags_to_merge)
 
     # set up training strategy

--- a/training_gradtape.py
+++ b/training_gradtape.py
@@ -410,7 +410,7 @@ if __name__ == '__main__':
                                                                                 sample_rate=config.sr, batch_size=config.batch, 
                                                                                 cycle_length=config.cycle_len, 
                                                                                 shuffle=config.shuffle, shuffle_buffer_size=config.shuffle_buffer, 
-                                                                                num_tags=config.tot_tags, window_size=config.window_len, window_random=config.window_random, 
+                                                                                num_tags=config.tot_tags, window_length=config.window_len, window_random=config.window_random, 
                                                                                 with_tags=config.tags, merge_tags=config.tags_to_merge,
 										                                        as_tuple=False)
     

--- a/training_gradtape.py
+++ b/training_gradtape.py
@@ -409,8 +409,8 @@ if __name__ == '__main__':
     train_dataset, valid_dataset = projectname_input.generate_datasets_from_dir(args.tfrecords_dir, args.frontend, split=config.split, which_split=(True, True, ) + (False, ) * (len(config.split)-2),
                                                                                 sample_rate=config.sr, batch_size=config.batch, 
                                                                                 cycle_length=config.cycle_len, 
-                                                                                shuffle=config.shuffle, buffer_size=config.shuffle_buffer, 
-                                                                                num_tags=config.tot_tags, window_size=config.window_len, random=config.window_random, 
+                                                                                shuffle=config.shuffle, shuffle_buffer_size=config.shuffle_buffer, 
+                                                                                num_tags=config.tot_tags, window_size=config.window_len, window_random=config.window_random, 
                                                                                 with_tags=config.tags, merge_tags=config.tags_to_merge,
 										                                        as_tuple=False)
     

--- a/utils.py
+++ b/utils.py
@@ -6,7 +6,7 @@ import time
 
 import numpy as np
 
-class WithoutIndent(object): # value wrapper
+class NoIndent(object): # value wrapper
     def __init__(self, value):
         self.value = value
 


### PR DESCRIPTION
Changelog:
1. Changed the var names slightly, in order to make them consistent with how I'd like the config.json  to be. I've tested both training script, and there are no typos.

2. The split array can be interpreted a percentage array, if the number in the split does not match the number of TFRecords (example, suppose you have 50 TFRecords: if split is [40, 5, 5] then that's interpreted as number of actual files, 40 files in train, 5 in valid and 5 in test; if split is [80 10 10] that's interpreted as 80%-10%-10%, and the outcome is the same). Clearly, this doesn't affect things at all if you're working with 100 TFrecords.

3. Instead of `if split is None` I do `if split`, this allows a null split to be [] (which allows you to do len(split)=0).

4. Add a simple _window function that returns either _window_1 or _window_2, again, just to make the code slightly more tidy (tested)